### PR TITLE
checkbox value reflection in submission.

### DIFF
--- a/mat-checkbox.html
+++ b/mat-checkbox.html
@@ -223,7 +223,8 @@ Generally, we recommend to use the `model` for data binding and `checked` to set
              */
             _adapt: function () {
                 var self = this;
-                self._setAdaptee(XP.appendChild(Polymer.dom(self), XP.createElement('input', {attributes: {type: self.type, checked: self.checked}})));
+                self._setAdaptee(XP.appendChild(Polymer.dom(self),
+                  XP.createElement('input', {attributes: {value: self.value, type: self.type, checked: self.checked}})));
                 return self;
             },
 
@@ -237,6 +238,7 @@ Generally, we recommend to use the `model` for data binding and `checked` to set
             _commitFrom: function () {
                 var self = this;
                 self.checked = self.adaptee.checked;
+                self.value = self.adaptee.value;
                 return self;
             },
 
@@ -249,7 +251,8 @@ Generally, we recommend to use the `model` for data binding and `checked` to set
              */
             _commitTo: function () {
                 var self = this;
-                if (self.checked !== self.adaptee.checked) { self.adaptee.checked = self.checked; }
+                if(self.checked !== self.adaptee.checked) { self.adaptee.checked = self.checked; }
+                if(self.value !== self.adaptee.value ) { self.adaptee.value = self.value };
                 return self;
             },
 
@@ -278,6 +281,7 @@ Generally, we recommend to use the `model` for data binding and `checked` to set
                 var self = this;
                 XP.setAttribute(self.adaptee, 'disabled', self.disabled);
                 XP.setAttribute(self.adaptee, 'name', self.name);
+                XP.setAttribute(self.adaptee, 'value', self.value);
                 return self;
             },
 

--- a/mat-checkbox.html
+++ b/mat-checkbox.html
@@ -251,7 +251,7 @@ Generally, we recommend to use the `model` for data binding and `checked` to set
             _commitTo: function () {
                 var self = this;
                 if (self.checked !== self.adaptee.checked) { self.adaptee.checked = self.checked; }
-                if (self.value !== self.adaptee.value ) { self.adaptee.value = self.value };
+                if (self.value !== self.adaptee.value ) { self.adaptee.value = self.value }
                 return self;
             },
 

--- a/mat-checkbox.html
+++ b/mat-checkbox.html
@@ -223,8 +223,7 @@ Generally, we recommend to use the `model` for data binding and `checked` to set
              */
             _adapt: function () {
                 var self = this;
-                self._setAdaptee(XP.appendChild(Polymer.dom(self),
-                  XP.createElement('input', {attributes: {value: self.value, type: self.type, checked: self.checked}})));
+                self._setAdaptee(XP.appendChild(Polymer.dom(self), XP.createElement('input', {attributes: {value: self.value, type: self.type, checked: self.checked}})));
                 return self;
             },
 
@@ -251,8 +250,8 @@ Generally, we recommend to use the `model` for data binding and `checked` to set
              */
             _commitTo: function () {
                 var self = this;
-                if(self.checked !== self.adaptee.checked) { self.adaptee.checked = self.checked; }
-                if(self.value !== self.adaptee.value ) { self.adaptee.value = self.value };
+                if (self.checked !== self.adaptee.checked) { self.adaptee.checked = self.checked; }
+                if (self.value !== self.adaptee.value ) { self.adaptee.value = self.value };
                 return self;
             },
 


### PR DESCRIPTION
Consider:

``` javascript
<form is='xp-form' content-type='application/json'>
    <mat-checkbox name='roles[]' value='adminstrator' checked></mat-checkbox>
    <mat-checkbox name='roles[]' value='user'></mat-checkbox>
    <mat-checkbox name='roles[]' value='guest' checked></mat-checkbox>
</form>
```

Upon submission of this form `roles[]` is filled in with `[on, on]` (or `[true, true]` for a `casted` form)

This makes no sense, because we don't know which two of the three toggles the user selected.

A checkbox is supposed to submit the 'value' attribute not the toggle state.  This was happening because the value attribute was not reflected into the adaptee.  This patch provides the fix.
